### PR TITLE
Fix root namespace for sqlite3 exceptions

### DIFF
--- a/src/SQLite.php
+++ b/src/SQLite.php
@@ -18,7 +18,7 @@
 
 				// Check write permissions of database
 				if (!is_writeable($path)) {
-					throw new Error("Permission denied: Can not write to directory '{$path}'");
+					throw new \Error("Permission denied: Can not write to directory '{$path}'");
 				}
 				
 				// Database doesn't exist and an init file as been provided


### PR DESCRIPTION
Fixes:
```
Error: Class "libsqlitedriver\Error" not found
```